### PR TITLE
Feature/v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+version 1.0
+- removed MessagePack
+- `send_message_to_service` now `send_request_to_service`
+- `send_message_to_resource` now `send_request_to_resource`
+- `send_message_to_queue` refactored to force HTTP packet format and is now `send_message_to_service`
+- `send_message_to_resource` added to allow non-response messages sent to resources
+- All message are now HTTP packet format, so logging must be updated.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ version 1.0
 - removed MessagePack
 - `send_message_to_service` now `send_request_to_service`
 - `send_message_to_resource` now `send_request_to_resource`
+- `send_message_to_queue` refactored to force HTTP packet format and is now `send_message_to_service`
 - `send_message_to_resource` added to allow non-response messages sent to resources
 - All message are now HTTP packet format, so logging must be updated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ version 1.0
 - removed MessagePack
 - `send_message_to_service` now `send_request_to_service`
 - `send_message_to_resource` now `send_request_to_resource`
-- `send_message_to_queue` refactored to force HTTP packet format and is now `send_message_to_service`
+- `send_message_to_queue` refactored to force HTTP packet format and is now `send_message_to_service` pass logging packet inside of `body` to `send_message_to_service`
 - `send_message_to_resource` added to allow non-response messages sent to resources
 - All message are now HTTP packet format, so logging must be updated.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@ version 1.0
 - removed MessagePack
 - `send_message_to_service` now `send_request_to_service`
 - `send_message_to_resource` now `send_request_to_resource`
-- `send_message_to_queue` refactored to force HTTP packet format and is now `send_message_to_service`
 - `send_message_to_resource` added to allow non-response messages sent to resources
 - All message are now HTTP packet format, so logging must be updated.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    alchemy-flux (0.1.2)
+    alchemy-flux (1.0.0)
       amqp (~> 1.5)
       eventmachine (~> 1.0)
       rack (~> 1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     alchemy-flux (0.1.2)
       amqp (~> 1.5)
       eventmachine (~> 1.0)
-      msgpack (~> 0.7)
       rack (~> 1.6)
       uuidtools (~> 2.1)
 
@@ -17,7 +16,6 @@ GEM
       eventmachine
     diff-lcs (1.2.5)
     eventmachine (1.0.9.1)
-    msgpack (0.7.4)
     rack (1.6.4)
     rake (10.5.0)
     rspec (3.4.0)
@@ -47,4 +45,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ service_a.start
 service_b.start
 
 # Synchronous message
-response = service_a1.send_message_to_service("B", {'body' => "Alice"})
+response = service_a1.send_request_to_service("B", {'body' => "Alice"})
 puts response['body'] # Hello Alice
 
 # Asynchronous message
-service_a1.send_message_to_service("B", {'body' => "Bob"}) do |response|
+service_a1.send_request_to_service("B", {'body' => "Bob"}) do |response|
   puts response['body'] # Hello Bob
 end
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bundle install
 bundle exec rackup -s alchemy
 ```
 
-The service will now be listening on RabbitMQ for incoming messages, running a router and calling over HTTP, or running another service will now work correctly.
+The service will now be listening on RabbitMQ for incoming messages, running a router and calling over HTTP, or calling directly from another service will be routed to this service.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,6 @@
 # Alchemy Flux
 
-## Alchemy Micro-services Framework
-
-The Alchemy [Micro-services](http://martinfowler.com/articles/microservices.html) Framework is a framework for creating many small interconnected services that communicate over the RabbitMQ message brokering service. Building services with Alchemy has many benefits, like:
-
-* **High Availability**: being able to run multiple services across many different machines, communicating to a High Availability RabbitMQ Cluster.
-* **Smart Load Balancing**: running multiple instances of the same service, will distribute messages to services based on the service capacity and not via a simple round robin approach.
-* **Service Discovery** Using RabbitMQ's routing of messages means services can communicate without knowing where they are located.
-* **Deployment** you can stop a service, then start a new service without missing any messages because they are buffered on RabbitMQ. Alternatively, you can run multiple versions of the same service concurrently to do rolling deploys.
-* **Error Recovery** If a service unexpectedly dies while processing a message, the message can be reprocessed by another service.
-* **Polyglot Architecture**: Each service can be implemented in the language that best suites its domain.
-
-## How Alchemy Services Work
-
-An Alchemy service communicates by registering two queues, a **service queue** (shared amongst all instances of a service) and a **response queue** (unique to that service instance). *For the purpose of clarity I will note a service with letters e.g. `A`, `B` and service instances with numbers, e.g. `A1` is service `A` instance `1`.*
-
-A service sends a message to another service by putting a message on its **service queue** (this message includes the **response queue** of the sender). An instance of that service will consume and process the message then respond to the received **response queue**. For example, if service `A1` wanted to message service `B`:
-
-```
-
-|----------|                                                  |------------|
-| RabbitMQ | <-- 1. Send message on queue B   --------------- | Service A1 |
-|          |                                                  |            |
-|          | --- 2. Consume Message from B  -> |------------| |            |
-|          |                                   | Service B1 | |            |
-|          | <-- 3. Respond on queue A1     -- |------------| |            |
-|          |                                                  |            |
-|----------| --- 4. Receive response on A1  ----------------> |------------|
-```
-
-Alchemy tries to reuse another common communication protocol, HTTP, for status codes, message formatting, headers and more. This way the basis of the messaging protocol is much simpler to explain and implement.
-
-Passing messages between services this way means that service `A1` can send messages to `B` without knowing which instance of `B` will process the message. If service `B1` becomes overloaded we can see the queue build up messages, and then start a new instance of service `B`, which, with zero configuration changes, immediately start processing messages.
-
-If the instance of `B` dies while processing a message, RabbitMQ will put the message back on the queue which can then be processed by another instance. This happens without the calling service knowing and so this makes the system much more resilient to errors. However, this also means that messages may be processed more than once, so implementing **idempotent** micro-services is very important.
-
-## Alchemy-Flux
-
-Alchemy-Flux is the Ruby implementation of the Alchemy Framework. Ruby is a great language to write in and works well with the Alchemy style of communication.
-
-Flux is implemented using the [EventMachine](https://github.com/eventmachine/eventmachine) and [AMQP](https://github.com/ruby-amqp/amqp) gems.
+Alchemy-Flux is the Ruby implementation of the [Alchemy Micro-Services Framework](https://github.com/LoyaltyNZ/alchemy-framework). Flux is implemented in Ruby using the [EventMachine](https://github.com/eventmachine/eventmachine) and [AMQP](https://github.com/ruby-amqp/amqp) gems, these work well with the Alchemy style of communication.
 
 ### Getting Started
 
@@ -77,6 +38,10 @@ sleep(1) # wait for asynchronous message to complete
 service_a.stop
 service_b.stop
 ```
+
+## Rack Implementation
+
+Alchemy Flux comes with an implementation in Rack so that other popular frameworks like Rails or Sinatra can be used with Alchemy. All you need to do is require the `alchemy-flux` gem into a project and run `rackup -s alchemy` to start the server with Alchemy.
 
 ## Documentation
 

--- a/alchemy-flux.gemspec
+++ b/alchemy-flux.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'alchemy-flux'
-  s.version     = '0.1.2'
+  s.version     = '1.0.0'
   s.summary     = "Ruby implementation of the Alchemy micro-service framework"
   s.description = "Ruby implementation of the Alchemy micro-service framework"
   s.authors     = [ 'Loyalty New Zealand']

--- a/alchemy-flux.gemspec
+++ b/alchemy-flux.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'eventmachine', '~> 1.0'
   s.add_runtime_dependency 'amqp', '~> 1.5'
   s.add_runtime_dependency 'uuidtools', '~> 2.1'
-  s.add_runtime_dependency 'msgpack', '~> 0.7'
 end

--- a/doc/AlchemyFlux.html
+++ b/doc/AlchemyFlux.html
@@ -117,9 +117,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/AlchemyFlux.html
+++ b/doc/AlchemyFlux.html
@@ -117,7 +117,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/AlchemyFlux/MessageNotDeliveredError.html
+++ b/doc/AlchemyFlux/MessageNotDeliveredError.html
@@ -125,9 +125,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/AlchemyFlux/MessageNotDeliveredError.html
+++ b/doc/AlchemyFlux/MessageNotDeliveredError.html
@@ -125,7 +125,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/AlchemyFlux/NAckError.html
+++ b/doc/AlchemyFlux/NAckError.html
@@ -126,7 +126,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/AlchemyFlux/NAckError.html
+++ b/doc/AlchemyFlux/NAckError.html
@@ -126,9 +126,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/AlchemyFlux/Service.html
+++ b/doc/AlchemyFlux/Service.html
@@ -1468,7 +1468,7 @@ asynchronously and yielded the response</p>
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/AlchemyFlux/Service.html
+++ b/doc/AlchemyFlux/Service.html
@@ -352,7 +352,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#send_message_to_queue-instance_method" title="#send_message_to_queue (instance method)">- (Object) <strong>send_message_to_queue</strong>(routing_key, message) </a>
+      <a href="#send_message_to_resource-instance_method" title="#send_message_to_resource (instance method)">- (Object) <strong>send_message_to_resource</strong>(message) </a>
     
 
     
@@ -367,31 +367,7 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>send a message to queue do not wait for response.</p>
-</div></span>
-  
-</li>
-
-      
-        <li class="public ">
-  <span class="summary_signature">
-    
-      <a href="#send_message_to_resource-instance_method" title="#send_message_to_resource (instance method)">- (Object) <strong>send_message_to_resource</strong>(http_message) </a>
-    
-
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>send a message to a resource.</p>
+<p>send a message to a resource, this does not wait for a response.</p>
 </div></span>
   
 </li>
@@ -415,7 +391,55 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>send a message to a service.</p>
+<p>send a message to a service, this does not wait for a response.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#send_request_to_resource-instance_method" title="#send_request_to_resource (instance method)">- (Object) <strong>send_request_to_resource</strong>(message) </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>send a message to a resource.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#send_request_to_service-instance_method" title="#send_request_to_service (instance method)">- (Object) <strong>send_request_to_service</strong>(service_name, message) </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>send a request to a service, this will wait for a response.</p>
 </div></span>
   
 </li>
@@ -956,9 +980,9 @@ but all the callbacks will be executed in the EM thread</p>
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="send_message_to_queue-instance_method">
+  <h3 class="signature " id="send_message_to_resource-instance_method">
   
-    - (<tt>Object</tt>) <strong>send_message_to_queue</strong>(routing_key, message) 
+    - (<tt>Object</tt>) <strong>send_message_to_resource</strong>(message) 
   
 
   
@@ -967,16 +991,11 @@ but all the callbacks will be executed in the EM thread</p>
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>send a message to queue do not wait for response</p>
-<dl class="rdoc-list note-list"><dt><strong>routing_key</strong>
+<p>send a message to a resource, this does not wait for a response</p>
+<dl class="rdoc-list note-list"><dt><strong>message</strong>
 <dd>
-<p>The routing key to use</p>
-</dd><dt><strong>message</strong>
-<dd>
-<p>The message to be sent</p>
-</dd><dt><strong>options</strong>
-<dd>
-<p>The message options</p>
+<p>HTTP formatted message to be sent, must contain `&#39;path&#39;` key with
+URL path</p>
 </dd></dl>
 
 
@@ -991,15 +1010,17 @@ but all the callbacks will be executed in the EM thread</p>
       <pre class="lines">
 
 
-309
-310
-311</pre>
+323
+324
+325
+326</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/alchemy-flux.rb', line 309</span>
+      <pre class="code"><span class="info file"># File 'lib/alchemy-flux.rb', line 323</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_send_message_to_queue'>send_message_to_queue</span><span class='lparen'>(</span><span class='id identifier rubyid_routing_key'>routing_key</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_send_message'>send_message</span><span class='lparen'>(</span> <span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_default_exchange'>default_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_routing_key'>routing_key</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='label'>type:</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ignore</span><span class='tstring_end'>&#39;</span></span><span class='rbrace'>}</span> <span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_send_message_to_resource'>send_message_to_resource</span><span class='lparen'>(</span><span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_routing_key'>routing_key</span> <span class='op'>=</span> <span class='id identifier rubyid_path_to_routing_key'>path_to_routing_key</span><span class='lparen'>(</span><span class='id identifier rubyid_message'>message</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>path</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_send_HTTP_message'>send_HTTP_message</span><span class='lparen'>(</span><span class='ivar'>@resources_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_routing_key'>routing_key</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1007,9 +1028,57 @@ but all the callbacks will be executed in the EM thread</p>
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="send_message_to_resource-instance_method">
+  <h3 class="signature " id="send_message_to_service-instance_method">
   
-    - (<tt>Object</tt>) <strong>send_message_to_resource</strong>(http_message) 
+    - (<tt>Object</tt>) <strong>send_message_to_service</strong>(service_name, message) 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>send a message to a service, this does not wait for a response</p>
+<dl class="rdoc-list note-list"><dt><strong>service_name</strong>
+<dd>
+<p>The name of the service</p>
+</dd><dt><strong>message</strong>
+<dd>
+<p>The message to be sent</p>
+</dd></dl>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+316
+317
+318</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/alchemy-flux.rb', line 316</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_send_HTTP_message'>send_HTTP_message</span><span class='lparen'>(</span><span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_default_exchange'>default_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="send_request_to_resource-instance_method">
+  
+    - (<tt>Object</tt>) <strong>send_request_to_resource</strong>(message) 
   
 
   
@@ -1019,9 +1088,75 @@ but all the callbacks will be executed in the EM thread</p>
   <div class="discussion">
     
 <p>send a message to a resource</p>
-<dl class="rdoc-list note-list"><dt><strong>http_message</strong>
+<dl class="rdoc-list note-list"><dt><strong>message</strong>
 <dd>
-<p>the message to be sent to the <strong>path</strong> in the message</p>
+<p>HTTP formatted message to be sent, must contain `&#39;path&#39;` key with
+URL path</p>
+</dd></dl>
+
+<p>This method can optionally take a block which will be executed
+asynchronously and yielded the response</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+349
+350
+351
+352
+353
+354
+355
+356
+357
+358</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/alchemy-flux.rb', line 349</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_send_request_to_resource'>send_request_to_resource</span><span class='lparen'>(</span><span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_routing_key'>routing_key</span> <span class='op'>=</span> <span class='id identifier rubyid_path_to_routing_key'>path_to_routing_key</span><span class='lparen'>(</span><span class='id identifier rubyid_message'>message</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>path</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='rparen'>)</span>
+  <span class='kw'>if</span> <span class='id identifier rubyid_block_given?'>block_given?</span>
+    <span class='const'>EventMachine</span><span class='period'>.</span><span class='id identifier rubyid_defer'>defer</span> <span class='kw'>do</span>
+      <span class='kw'>yield</span> <span class='id identifier rubyid_send_request_to_resource'>send_request_to_resource</span><span class='lparen'>(</span><span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+    <span class='kw'>end</span>
+  <span class='kw'>else</span>
+    <span class='id identifier rubyid_send_HTTP_request'>send_HTTP_request</span><span class='lparen'>(</span><span class='ivar'>@resources_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_routing_key'>routing_key</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+  <span class='kw'>end</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="send_request_to_service-instance_method">
+  
+    - (<tt>Object</tt>) <strong>send_request_to_service</strong>(service_name, message) 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>send a request to a service, this will wait for a response</p>
+<dl class="rdoc-list note-list"><dt><strong>service_name</strong>
+<dd>
+<p>the name of the service</p>
+</dd><dt><strong>message</strong>
+<dd>
+<p>the message to be sent</p>
 </dd></dl>
 
 <p>This method can optionally take a block which will be executed
@@ -1047,83 +1182,18 @@ asynchronously and yielded the response</p>
 339
 340
 341
-342
-343</pre>
+342</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/alchemy-flux.rb', line 334</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_send_message_to_resource'>send_message_to_resource</span><span class='lparen'>(</span><span class='id identifier rubyid_http_message'>http_message</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_routing_key'>routing_key</span> <span class='op'>=</span> <span class='id identifier rubyid_path_to_routing_key'>path_to_routing_key</span><span class='lparen'>(</span><span class='id identifier rubyid_http_message'>http_message</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>path</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_send_request_to_service'>send_request_to_service</span><span class='lparen'>(</span><span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
   <span class='kw'>if</span> <span class='id identifier rubyid_block_given?'>block_given?</span>
     <span class='const'>EventMachine</span><span class='period'>.</span><span class='id identifier rubyid_defer'>defer</span> <span class='kw'>do</span>
-      <span class='kw'>yield</span> <span class='id identifier rubyid_send_message_to_resource'>send_message_to_resource</span><span class='lparen'>(</span><span class='id identifier rubyid_http_message'>http_message</span><span class='rparen'>)</span>
+      <span class='kw'>yield</span> <span class='id identifier rubyid_send_request_to_service'>send_request_to_service</span><span class='lparen'>(</span><span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
     <span class='kw'>end</span>
   <span class='kw'>else</span>
-    <span class='id identifier rubyid_send_HTTP_request_message'>send_HTTP_request_message</span><span class='lparen'>(</span><span class='ivar'>@resources_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_routing_key'>routing_key</span><span class='comma'>,</span> <span class='id identifier rubyid_http_message'>http_message</span><span class='rparen'>)</span>
-  <span class='kw'>end</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
-      <div class="method_details ">
-  <h3 class="signature " id="send_message_to_service-instance_method">
-  
-    - (<tt>Object</tt>) <strong>send_message_to_service</strong>(service_name, message) 
-  
-
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>send a message to a service</p>
-<dl class="rdoc-list note-list"><dt><strong>service_name</strong>
-<dd>
-<p>the name of the service</p>
-</dd><dt><strong>message</strong>
-<dd>
-<p>the message to be sent</p>
-</dd></dl>
-
-<p>This method can optionally take a block which will be executed
-asynchronously and yielded the response</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-319
-320
-321
-322
-323
-324
-325
-326
-327</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/alchemy-flux.rb', line 319</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
-  <span class='kw'>if</span> <span class='id identifier rubyid_block_given?'>block_given?</span>
-    <span class='const'>EventMachine</span><span class='period'>.</span><span class='id identifier rubyid_defer'>defer</span> <span class='kw'>do</span>
-      <span class='kw'>yield</span> <span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
-    <span class='kw'>end</span>
-  <span class='kw'>else</span>
-    <span class='id identifier rubyid_send_HTTP_request_message'>send_HTTP_request_message</span><span class='lparen'>(</span><span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_default_exchange'>default_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
+    <span class='id identifier rubyid_send_HTTP_request'>send_HTTP_request</span><span class='lparen'>(</span><span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_default_exchange'>default_exchange</span><span class='comma'>,</span> <span class='id identifier rubyid_service_name'>service_name</span><span class='comma'>,</span> <span class='id identifier rubyid_message'>message</span><span class='rparen'>)</span>
   <span class='kw'>end</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -1236,25 +1306,25 @@ asynchronously and yielded the response</p>
 
     <span class='ivar'>@service_queue</span> <span class='op'>=</span> <span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_queue'>queue</span><span class='lparen'>(</span> <span class='ivar'>@service_queue_name</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='symbol'>:durable</span> <span class='op'>=&gt;</span> <span class='kw'>true</span><span class='rbrace'>}</span><span class='rparen'>)</span>
     <span class='ivar'>@service_queue</span><span class='period'>.</span><span class='id identifier rubyid_subscribe'>subscribe</span><span class='lparen'>(</span><span class='lbrace'>{</span><span class='symbol'>:ack</span> <span class='op'>=&gt;</span> <span class='kw'>true</span><span class='rbrace'>}</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_metadata'>metadata</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='op'>|</span>
-      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>MessagePack</span><span class='period'>.</span><span class='id identifier rubyid_unpack'>unpack</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
+      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
       <span class='id identifier rubyid_process_service_queue_message'>process_service_queue_message</span><span class='lparen'>(</span><span class='id identifier rubyid_metadata'>metadata</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
     <span class='kw'>end</span>
 
     <span class='id identifier rubyid_response_queue'>response_queue</span> <span class='op'>=</span> <span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_queue'>queue</span><span class='lparen'>(</span><span class='ivar'>@response_queue_name</span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='symbol'>:exclusive</span> <span class='op'>=&gt;</span> <span class='kw'>true</span><span class='comma'>,</span> <span class='symbol'>:auto_delete</span> <span class='op'>=&gt;</span> <span class='kw'>true</span><span class='rbrace'>}</span><span class='rparen'>)</span>
     <span class='id identifier rubyid_response_queue'>response_queue</span><span class='period'>.</span><span class='id identifier rubyid_subscribe'>subscribe</span><span class='lparen'>(</span><span class='lbrace'>{</span><span class='rbrace'>}</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_metadata'>metadata</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='op'>|</span>
-      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>MessagePack</span><span class='period'>.</span><span class='id identifier rubyid_unpack'>unpack</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
+      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
       <span class='id identifier rubyid_process_response_queue_message'>process_response_queue_message</span><span class='lparen'>(</span><span class='id identifier rubyid_metadata'>metadata</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
     <span class='kw'>end</span>
 
     <span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_default_exchange'>default_exchange</span><span class='period'>.</span><span class='id identifier rubyid_on_return'>on_return</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_basic_return'>basic_return</span><span class='comma'>,</span> <span class='id identifier rubyid_frame'>frame</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='op'>|</span>
-      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>MessagePack</span><span class='period'>.</span><span class='id identifier rubyid_unpack'>unpack</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
+      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
       <span class='id identifier rubyid_process_returned_message'>process_returned_message</span><span class='lparen'>(</span><span class='id identifier rubyid_basic_return'>basic_return</span><span class='comma'>,</span> <span class='id identifier rubyid_frame'>frame</span><span class='period'>.</span><span class='id identifier rubyid_properties'>properties</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
     <span class='kw'>end</span>
 
     <span class='comment'># RESOURCES HANDLE
 </span>    <span class='ivar'>@resources_exchange</span> <span class='op'>=</span> <span class='ivar'>@channel</span><span class='period'>.</span><span class='id identifier rubyid_topic'>topic</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>resources.exchange</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='symbol'>:durable</span> <span class='op'>=&gt;</span> <span class='kw'>true</span><span class='rbrace'>}</span><span class='rparen'>)</span>
     <span class='ivar'>@resources_exchange</span><span class='period'>.</span><span class='id identifier rubyid_on_return'>on_return</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_basic_return'>basic_return</span><span class='comma'>,</span> <span class='id identifier rubyid_frame'>frame</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='op'>|</span>
-      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>MessagePack</span><span class='period'>.</span><span class='id identifier rubyid_unpack'>unpack</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
+      <span class='id identifier rubyid_payload'>payload</span> <span class='op'>=</span> <span class='const'>JSON</span><span class='period'>.</span><span class='id identifier rubyid_parse'>parse</span><span class='lparen'>(</span><span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
       <span class='id identifier rubyid_process_returned_message'>process_returned_message</span><span class='lparen'>(</span><span class='id identifier rubyid_basic_return'>basic_return</span><span class='comma'>,</span> <span class='id identifier rubyid_frame'>frame</span><span class='period'>.</span><span class='id identifier rubyid_properties'>properties</span><span class='comma'>,</span> <span class='id identifier rubyid_payload'>payload</span><span class='rparen'>)</span>
     <span class='kw'>end</span>
 
@@ -1398,9 +1468,9 @@ asynchronously and yielded the response</p>
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/AlchemyFlux/TimeoutError.html
+++ b/doc/AlchemyFlux/TimeoutError.html
@@ -125,9 +125,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/AlchemyFlux/TimeoutError.html
+++ b/doc/AlchemyFlux/TimeoutError.html
@@ -125,7 +125,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/Rack.html
+++ b/doc/Rack.html
@@ -117,9 +117,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/Rack.html
+++ b/doc/Rack.html
@@ -117,7 +117,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/Rack/Handler.html
+++ b/doc/Rack/Handler.html
@@ -117,9 +117,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/Rack/Handler.html
+++ b/doc/Rack/Handler.html
@@ -117,7 +117,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/Rack/Handler/AlchemyFlux.html
+++ b/doc/Rack/Handler/AlchemyFlux.html
@@ -653,7 +653,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/Rack/Handler/AlchemyFlux.html
+++ b/doc/Rack/Handler/AlchemyFlux.html
@@ -567,9 +567,9 @@
 
   <span class='id identifier rubyid_options'>options</span> <span class='op'>=</span> <span class='lbrace'>{</span>
     <span class='label'>ampq_uri:</span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>AMQ_URI</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>amqp://localhost</span><span class='tstring_end'>&#39;</span></span><span class='comma'>,</span>
-    <span class='label'>prefetch:</span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>PREFETCH</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='int'>20</span><span class='comma'>,</span>
-    <span class='label'>timeout:</span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>TIMEOUT</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='int'>30000</span><span class='comma'>,</span>
-    <span class='label'>threadpool_size:</span> <span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>THREADPOOL_SIZE</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='int'>500</span><span class='comma'>,</span>
+    <span class='label'>prefetch:</span> <span class='lparen'>(</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>PREFETCH</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='int'>20</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>timeout:</span> <span class='lparen'>(</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>TIMEOUT</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='int'>30000</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
+    <span class='label'>threadpool_size:</span> <span class='lparen'>(</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>THREADPOOL_SIZE</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='int'>500</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span><span class='comma'>,</span>
     <span class='label'>resource_paths:</span> <span class='lparen'>(</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ALCHEMY_RESOURCE_PATHS</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>||</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_split'>split</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>,</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
   <span class='rbrace'>}</span>
 
@@ -653,9 +653,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -196,7 +196,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -196,9 +196,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -110,9 +110,71 @@ have instance <code>A1</code> call service <code>B</code>:</p>
 <h2 id="label-Rack+Implementation">Rack Implementation</h2>
 
 <p>Alchemy Flux comes with an implementation in Rack so that other popular
-frameworks like Rails or Sinatra can be used with Alchemy. All you need to
-do is require the <code>alchemy-flux</code> gem into a project and run
-<code>rackup -s alchemy</code> to start the server with Alchemy.</p>
+frameworks like Rails or Sinatra can be used with Alchemy. The main
+configuration is done through environment variables:</p>
+<ol><li>
+<p><code>ALCHEMY_SERVICE_NAME</code>: the name of the service.
+<strong>REQUIRED</strong></p>
+</li><li>
+<p><code>AMQ_URI</code>: URL of the RabbitMQ cluster. Default is
+<code>&#39;amqp://localhost&#39;</code>,</p>
+</li><li>
+<p><code>PREFETCH</code>: the number of messages to prefetch from RabbitMQ and
+handle concurrently. Default is <code>20</code>.</p>
+</li><li>
+<p><code>TIMEOUT</code>: the amount of milliseconds the service will wait for
+outgoing requests. Default is <code>30000</code></p>
+</li><li>
+<p><code>THREADPOOL_SIZE</code>: number of Event Machine Threads, must be
+greater than <code>PREFETCH</code> and should be as it represents the
+number of async calls and requests the service can handle. Default is
+<code>500</code></p>
+</li><li>
+<p><code>ALCHEMY_RESOURCE_PATHS</code>: a comma separated list of resource
+paths that are handled by this service e.g.
+<code>&#39;/v1/users,/v1/admins&#39;</code>. Default is
+<code>&#39;&#39;</code></p>
+</li></ol>
+
+<p>Then <code>alchemy-flux</code> gem into a project and run <code>rackup -s
+alchemy</code> to start the server with Alchemy.</p>
+
+<p>For example, to run a simple Sinatra application in the Alchemy framework
+you will need the files:</p>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'># ./Gemfile
+</span><span class='id identifier rubyid_source'>source</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https://rubygems.org</span><span class='tstring_end'>&#39;</span></span>
+
+<span class='id identifier rubyid_gem'>gem</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>sinatra</span><span class='tstring_end'>&#39;</span></span>
+<span class='id identifier rubyid_gem'>gem</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>alchemy-flux</span><span class='tstring_end'>&#39;</span></span>
+</code></pre>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'># ./config.ru
+</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ALCHEMY_SERVICE_NAME</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>helloworld.service</span><span class='tstring_end'>&#39;</span></span>
+<span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ALCHEMY_RESOURCE_PATHS</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/v1/hello</span><span class='tstring_end'>&#39;</span></span>
+
+<span class='id identifier rubyid_require'>require</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>alchemy-flux</span><span class='tstring_end'>&#39;</span></span>
+<span class='id identifier rubyid_require'>require</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>./service</span><span class='tstring_end'>&#39;</span></span>
+<span class='id identifier rubyid_run'>run</span> <span class='const'>Sinatra</span><span class='op'>::</span><span class='const'>Application</span>
+</code></pre>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'># ./service.rb
+</span><span class='id identifier rubyid_require'>require</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>sinatra</span><span class='tstring_end'>&#39;</span></span>
+
+<span class='id identifier rubyid_get'>get</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/v1/hello</span><span class='tstring_end'>&#39;</span></span> <span class='kw'>do</span>
+  <span class='id identifier rubyid_content_type'>content_type</span> <span class='symbol'>:json</span>
+  <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>hello</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>world!</span><span class='tstring_end'>&#39;</span></span><span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span>
+<span class='kw'>end</span>
+</code></pre>
+
+<p>Then run:</p>
+
+<pre class="code ruby"><code class="ruby">bundle install
+bundle exec rackup -s alchemy</code></pre>
+
+<p>The service will now be listening on RabbitMQ for incoming messages,
+running a router and calling over HTTP, or running another service will now
+work correctly.</p>
 
 <h2 id="label-Documentation">Documentation</h2>
 
@@ -135,7 +197,7 @@ href="https://rubygems.org/gems/yard/versions/0.8.7.6">yard</a>.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -64,90 +64,12 @@
     <div id="content"><div id='filecontents'>
 <h1 id="label-Alchemy+Flux">Alchemy Flux</h1>
 
-<h2 id="label-Alchemy+Micro-services+Framework">Alchemy Micro-services Framework</h2>
-
-<p>The Alchemy <a
-href="http://martinfowler.com/articles/microservices.html">Micro-services</a>
-Framework is a framework for creating many small interconnected services
-that communicate over the RabbitMQ message brokering service. Building
-services with Alchemy has many benefits, like:</p>
-<ul><li>
-<p><strong>High Availability</strong>: being able to run multiple services
-across many different machines, communicating to a High Availability
-RabbitMQ Cluster.</p>
-</li><li>
-<p><strong>Smart Load Balancing</strong>: running multiple instances of the
-same service, will distribute messages to services based on the service
-capacity and not via a simple round robin approach.</p>
-</li><li>
-<p><strong>Service Discovery</strong> Using RabbitMQ&#39;s routing of messages
-means services can communicate without knowing where they are located.</p>
-</li><li>
-<p><strong>Deployment</strong> you can stop a service, then start a new
-service without missing any messages because they are buffered on RabbitMQ.
-Alternatively, you can run multiple versions of the same service
-concurrently to do rolling deploys.</p>
-</li><li>
-<p><strong>Error Recovery</strong> If a service unexpectedly dies while
-processing a message, the message can be reprocessed by another service.</p>
-</li><li>
-<p><strong>Polyglot Architecture</strong>: Each service can be implemented in
-the language that best suites its domain.</p>
-</li></ul>
-
-<h2 id="label-How+Alchemy+Services+Work">How Alchemy Services Work</h2>
-
-<p>An Alchemy service communicates by registering two queues, a
-<strong>service queue</strong> (shared amongst all instances of a service)
-and a <strong>response queue</strong> (unique to that service instance).
-<em>For the purpose of clarity I will note a service with letters e.g.
-<code>A</code>, <code>B</code> and service instances with numbers, e.g.
-<code>A1</code> is service <code>A</code> instance <code>1</code>.</em></p>
-
-<p>A service sends a message to another service by putting a message on its
-<strong>service queue</strong> (this message includes the <strong>response
-queue</strong> of the sender). An instance of that service will consume and
-process the message then respond to the received <strong>response
-queue</strong>. For example, if service <code>A1</code> wanted to message
-service <code>B</code>:</p>
-
-<pre class="code ruby"><code class="ruby">
-|----------|                                                  |------------|
-| RabbitMQ | &lt;-- 1. Send message on queue B   --------------- | Service A1 |
-|          |                                                  |            |
-|          | --- 2. Consume Message from B  -&gt; |------------| |            |
-|          |                                   | Service B1 | |            |
-|          | &lt;-- 3. Respond on queue A1     -- |------------| |            |
-|          |                                                  |            |
-|----------| --- 4. Receive response on A1  ----------------&gt; |------------|</code></pre>
-
-<p>Alchemy tries to reuse another common communication protocol, HTTP, for
-status codes, message formatting, headers and more. This way the basis of
-the messaging protocol is much simpler to explain and implement.</p>
-
-<p>Passing messages between services this way means that service
-<code>A1</code> can send messages to <code>B</code> without knowing which
-instance of <code>B</code> will process the message. If service
-<code>B1</code> becomes overloaded we can see the queue build up messages,
-and then start a new instance of service <code>B</code>, which, with zero
-configuration changes, immediately start processing messages.</p>
-
-<p>If the instance of <code>B</code> dies while processing a message, RabbitMQ
-will put the message back on the queue which can then be processed by
-another instance. This happens without the calling service knowing and so
-this makes the system much more resilient to errors. However, this also
-means that messages may be processed more than once, so implementing
-<strong>idempotent</strong> micro-services is very important.</p>
-
-<h2 id="label-Alchemy-Flux">Alchemy-Flux</h2>
-
-<p>Alchemy-Flux is the Ruby implementation of the Alchemy Framework. Ruby is a
-great language to write in and works well with the Alchemy style of
-communication.</p>
-
-<p>Flux is implemented using the <a
+<p>Alchemy-Flux is the Ruby implementation of the <a
+href="https://github.com/LoyaltyNZ/alchemy-framework">Alchemy
+Micro-Services Framework</a>. Flux is implemented in Ruby using the <a
 href="https://github.com/eventmachine/eventmachine">EventMachine</a> and <a
-href="https://github.com/ruby-amqp/amqp">AMQP</a> gems.</p>
+href="https://github.com/ruby-amqp/amqp">AMQP</a> gems, these work well
+with the Alchemy style of communication.</p>
 
 <h3 id="label-Getting+Started">Getting Started</h3>
 
@@ -171,11 +93,11 @@ have instance <code>A1</code> call service <code>B</code>:</p>
 <span class='id identifier rubyid_service_b'>service_b</span><span class='period'>.</span><span class='id identifier rubyid_start'>start</span>
 
 <span class='comment'># Synchronous message
-</span><span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Alice</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span>
+</span><span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_request_to_service'>send_request_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Alice</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span>
 <span class='id identifier rubyid_puts'>puts</span> <span class='id identifier rubyid_response'>response</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'># Hello Alice
 </span>
 <span class='comment'># Asynchronous message
-</span><span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Bob</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_response'>response</span><span class='op'>|</span>
+</span><span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_request_to_service'>send_request_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Bob</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_response'>response</span><span class='op'>|</span>
   <span class='id identifier rubyid_puts'>puts</span> <span class='id identifier rubyid_response'>response</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'># Hello Bob
 </span><span class='kw'>end</span>
 
@@ -184,6 +106,13 @@ have instance <code>A1</code> call service <code>B</code>:</p>
 <span class='id identifier rubyid_service_a'>service_a</span><span class='period'>.</span><span class='id identifier rubyid_stop'>stop</span>
 <span class='id identifier rubyid_service_b'>service_b</span><span class='period'>.</span><span class='id identifier rubyid_stop'>stop</span>
 </code></pre>
+
+<h2 id="label-Rack+Implementation">Rack Implementation</h2>
+
+<p>Alchemy Flux comes with an implementation in Rack so that other popular
+frameworks like Rails or Sinatra can be used with Alchemy. All you need to
+do is require the <code>alchemy-flux</code> gem into a project and run
+<code>rackup -s alchemy</code> to start the server with Alchemy.</p>
 
 <h2 id="label-Documentation">Documentation</h2>
 
@@ -206,9 +135,9 @@ href="https://rubygems.org/gems/yard/versions/0.8.7.6">yard</a>.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/index.html
+++ b/doc/index.html
@@ -110,9 +110,71 @@ have instance <code>A1</code> call service <code>B</code>:</p>
 <h2 id="label-Rack+Implementation">Rack Implementation</h2>
 
 <p>Alchemy Flux comes with an implementation in Rack so that other popular
-frameworks like Rails or Sinatra can be used with Alchemy. All you need to
-do is require the <code>alchemy-flux</code> gem into a project and run
-<code>rackup -s alchemy</code> to start the server with Alchemy.</p>
+frameworks like Rails or Sinatra can be used with Alchemy. The main
+configuration is done through environment variables:</p>
+<ol><li>
+<p><code>ALCHEMY_SERVICE_NAME</code>: the name of the service.
+<strong>REQUIRED</strong></p>
+</li><li>
+<p><code>AMQ_URI</code>: URL of the RabbitMQ cluster. Default is
+<code>&#39;amqp://localhost&#39;</code>,</p>
+</li><li>
+<p><code>PREFETCH</code>: the number of messages to prefetch from RabbitMQ and
+handle concurrently. Default is <code>20</code>.</p>
+</li><li>
+<p><code>TIMEOUT</code>: the amount of milliseconds the service will wait for
+outgoing requests. Default is <code>30000</code></p>
+</li><li>
+<p><code>THREADPOOL_SIZE</code>: number of Event Machine Threads, must be
+greater than <code>PREFETCH</code> and should be as it represents the
+number of async calls and requests the service can handle. Default is
+<code>500</code></p>
+</li><li>
+<p><code>ALCHEMY_RESOURCE_PATHS</code>: a comma separated list of resource
+paths that are handled by this service e.g.
+<code>&#39;/v1/users,/v1/admins&#39;</code>. Default is
+<code>&#39;&#39;</code></p>
+</li></ol>
+
+<p>Then <code>alchemy-flux</code> gem into a project and run <code>rackup -s
+alchemy</code> to start the server with Alchemy.</p>
+
+<p>For example, to run a simple Sinatra application in the Alchemy framework
+you will need the files:</p>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'># ./Gemfile
+</span><span class='id identifier rubyid_source'>source</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>https://rubygems.org</span><span class='tstring_end'>&#39;</span></span>
+
+<span class='id identifier rubyid_gem'>gem</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>sinatra</span><span class='tstring_end'>&#39;</span></span>
+<span class='id identifier rubyid_gem'>gem</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>alchemy-flux</span><span class='tstring_end'>&#39;</span></span>
+</code></pre>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'># ./config.ru
+</span><span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ALCHEMY_SERVICE_NAME</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>helloworld.service</span><span class='tstring_end'>&#39;</span></span>
+<span class='const'>ENV</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>ALCHEMY_RESOURCE_PATHS</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/v1/hello</span><span class='tstring_end'>&#39;</span></span>
+
+<span class='id identifier rubyid_require'>require</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>alchemy-flux</span><span class='tstring_end'>&#39;</span></span>
+<span class='id identifier rubyid_require'>require</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>./service</span><span class='tstring_end'>&#39;</span></span>
+<span class='id identifier rubyid_run'>run</span> <span class='const'>Sinatra</span><span class='op'>::</span><span class='const'>Application</span>
+</code></pre>
+
+<pre class="code ruby"><code class="ruby"><span class='comment'># ./service.rb
+</span><span class='id identifier rubyid_require'>require</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>sinatra</span><span class='tstring_end'>&#39;</span></span>
+
+<span class='id identifier rubyid_get'>get</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>/v1/hello</span><span class='tstring_end'>&#39;</span></span> <span class='kw'>do</span>
+  <span class='id identifier rubyid_content_type'>content_type</span> <span class='symbol'>:json</span>
+  <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>hello</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>world!</span><span class='tstring_end'>&#39;</span></span><span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_to_json'>to_json</span>
+<span class='kw'>end</span>
+</code></pre>
+
+<p>Then run:</p>
+
+<pre class="code ruby"><code class="ruby">bundle install
+bundle exec rackup -s alchemy</code></pre>
+
+<p>The service will now be listening on RabbitMQ for incoming messages,
+running a router and calling over HTTP, or running another service will now
+work correctly.</p>
 
 <h2 id="label-Documentation">Documentation</h2>
 
@@ -135,7 +197,7 @@ href="https://rubygems.org/gems/yard/versions/0.8.7.6">yard</a>.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/index.html
+++ b/doc/index.html
@@ -64,90 +64,12 @@
     <div id="content"><div id='filecontents'>
 <h1 id="label-Alchemy+Flux">Alchemy Flux</h1>
 
-<h2 id="label-Alchemy+Micro-services+Framework">Alchemy Micro-services Framework</h2>
-
-<p>The Alchemy <a
-href="http://martinfowler.com/articles/microservices.html">Micro-services</a>
-Framework is a framework for creating many small interconnected services
-that communicate over the RabbitMQ message brokering service. Building
-services with Alchemy has many benefits, like:</p>
-<ul><li>
-<p><strong>High Availability</strong>: being able to run multiple services
-across many different machines, communicating to a High Availability
-RabbitMQ Cluster.</p>
-</li><li>
-<p><strong>Smart Load Balancing</strong>: running multiple instances of the
-same service, will distribute messages to services based on the service
-capacity and not via a simple round robin approach.</p>
-</li><li>
-<p><strong>Service Discovery</strong> Using RabbitMQ&#39;s routing of messages
-means services can communicate without knowing where they are located.</p>
-</li><li>
-<p><strong>Deployment</strong> you can stop a service, then start a new
-service without missing any messages because they are buffered on RabbitMQ.
-Alternatively, you can run multiple versions of the same service
-concurrently to do rolling deploys.</p>
-</li><li>
-<p><strong>Error Recovery</strong> If a service unexpectedly dies while
-processing a message, the message can be reprocessed by another service.</p>
-</li><li>
-<p><strong>Polyglot Architecture</strong>: Each service can be implemented in
-the language that best suites its domain.</p>
-</li></ul>
-
-<h2 id="label-How+Alchemy+Services+Work">How Alchemy Services Work</h2>
-
-<p>An Alchemy service communicates by registering two queues, a
-<strong>service queue</strong> (shared amongst all instances of a service)
-and a <strong>response queue</strong> (unique to that service instance).
-<em>For the purpose of clarity I will note a service with letters e.g.
-<code>A</code>, <code>B</code> and service instances with numbers, e.g.
-<code>A1</code> is service <code>A</code> instance <code>1</code>.</em></p>
-
-<p>A service sends a message to another service by putting a message on its
-<strong>service queue</strong> (this message includes the <strong>response
-queue</strong> of the sender). An instance of that service will consume and
-process the message then respond to the received <strong>response
-queue</strong>. For example, if service <code>A1</code> wanted to message
-service <code>B</code>:</p>
-
-<pre class="code ruby"><code class="ruby">
-|----------|                                                  |------------|
-| RabbitMQ | &lt;-- 1. Send message on queue B   --------------- | Service A1 |
-|          |                                                  |            |
-|          | --- 2. Consume Message from B  -&gt; |------------| |            |
-|          |                                   | Service B1 | |            |
-|          | &lt;-- 3. Respond on queue A1     -- |------------| |            |
-|          |                                                  |            |
-|----------| --- 4. Receive response on A1  ----------------&gt; |------------|</code></pre>
-
-<p>Alchemy tries to reuse another common communication protocol, HTTP, for
-status codes, message formatting, headers and more. This way the basis of
-the messaging protocol is much simpler to explain and implement.</p>
-
-<p>Passing messages between services this way means that service
-<code>A1</code> can send messages to <code>B</code> without knowing which
-instance of <code>B</code> will process the message. If service
-<code>B1</code> becomes overloaded we can see the queue build up messages,
-and then start a new instance of service <code>B</code>, which, with zero
-configuration changes, immediately start processing messages.</p>
-
-<p>If the instance of <code>B</code> dies while processing a message, RabbitMQ
-will put the message back on the queue which can then be processed by
-another instance. This happens without the calling service knowing and so
-this makes the system much more resilient to errors. However, this also
-means that messages may be processed more than once, so implementing
-<strong>idempotent</strong> micro-services is very important.</p>
-
-<h2 id="label-Alchemy-Flux">Alchemy-Flux</h2>
-
-<p>Alchemy-Flux is the Ruby implementation of the Alchemy Framework. Ruby is a
-great language to write in and works well with the Alchemy style of
-communication.</p>
-
-<p>Flux is implemented using the <a
+<p>Alchemy-Flux is the Ruby implementation of the <a
+href="https://github.com/LoyaltyNZ/alchemy-framework">Alchemy
+Micro-Services Framework</a>. Flux is implemented in Ruby using the <a
 href="https://github.com/eventmachine/eventmachine">EventMachine</a> and <a
-href="https://github.com/ruby-amqp/amqp">AMQP</a> gems.</p>
+href="https://github.com/ruby-amqp/amqp">AMQP</a> gems, these work well
+with the Alchemy style of communication.</p>
 
 <h3 id="label-Getting+Started">Getting Started</h3>
 
@@ -171,11 +93,11 @@ have instance <code>A1</code> call service <code>B</code>:</p>
 <span class='id identifier rubyid_service_b'>service_b</span><span class='period'>.</span><span class='id identifier rubyid_start'>start</span>
 
 <span class='comment'># Synchronous message
-</span><span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Alice</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span>
+</span><span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_request_to_service'>send_request_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Alice</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span>
 <span class='id identifier rubyid_puts'>puts</span> <span class='id identifier rubyid_response'>response</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'># Hello Alice
 </span>
 <span class='comment'># Asynchronous message
-</span><span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_message_to_service'>send_message_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Bob</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_response'>response</span><span class='op'>|</span>
+</span><span class='id identifier rubyid_service_a1'>service_a1</span><span class='period'>.</span><span class='id identifier rubyid_send_request_to_service'>send_request_to_service</span><span class='lparen'>(</span><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>B</span><span class='tstring_end'>&quot;</span></span><span class='comma'>,</span> <span class='lbrace'>{</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Bob</span><span class='tstring_end'>&quot;</span></span><span class='rbrace'>}</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_response'>response</span><span class='op'>|</span>
   <span class='id identifier rubyid_puts'>puts</span> <span class='id identifier rubyid_response'>response</span><span class='lbracket'>[</span><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>body</span><span class='tstring_end'>&#39;</span></span><span class='rbracket'>]</span> <span class='comment'># Hello Bob
 </span><span class='kw'>end</span>
 
@@ -184,6 +106,13 @@ have instance <code>A1</code> call service <code>B</code>:</p>
 <span class='id identifier rubyid_service_a'>service_a</span><span class='period'>.</span><span class='id identifier rubyid_stop'>stop</span>
 <span class='id identifier rubyid_service_b'>service_b</span><span class='period'>.</span><span class='id identifier rubyid_stop'>stop</span>
 </code></pre>
+
+<h2 id="label-Rack+Implementation">Rack Implementation</h2>
+
+<p>Alchemy Flux comes with an implementation in Rack so that other popular
+frameworks like Rails or Sinatra can be used with Alchemy. All you need to
+do is require the <code>alchemy-flux</code> gem into a project and run
+<code>rackup -s alchemy</code> to start the server with Alchemy.</p>
 
 <h2 id="label-Documentation">Documentation</h2>
 
@@ -206,9 +135,9 @@ href="https://rubygems.org/gems/yard/versions/0.8.7.6">yard</a>.</p>
 </div></div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/doc/method_list.html
+++ b/doc/method_list.html
@@ -88,19 +88,31 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="AlchemyFlux/Service.html#send_message_to_queue-instance_method" title="AlchemyFlux::Service#send_message_to_queue (method)">#send_message_to_queue</a></span>
-    <small>AlchemyFlux::Service</small>
-  </li>
-  
-
-  <li class="r2 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#send_message_to_resource-instance_method" title="AlchemyFlux::Service#send_message_to_resource (method)">#send_message_to_resource</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
 
-  <li class="r1 ">
+  <li class="r2 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#send_message_to_service-instance_method" title="AlchemyFlux::Service#send_message_to_service (method)">#send_message_to_service</a></span>
+    <small>AlchemyFlux::Service</small>
+  </li>
+  
+
+  <li class="r1 ">
+    <span class='object_link'><a href="AlchemyFlux/Service.html#send_request_to_resource-instance_method" title="AlchemyFlux::Service#send_request_to_resource (method)">#send_request_to_resource</a></span>
+    <small>AlchemyFlux::Service</small>
+  </li>
+  
+
+  <li class="r2 ">
+    <span class='object_link'><a href="AlchemyFlux/Service.html#send_request_to_service-instance_method" title="AlchemyFlux::Service#send_request_to_service (method)">#send_request_to_service</a></span>
+    <small>AlchemyFlux::Service</small>
+  </li>
+  
+
+  <li class="r1 ">
+    <span class='object_link'><a href="AlchemyFlux/Service.html#start-class_method" title="AlchemyFlux::Service.start (method)">start</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
@@ -112,48 +124,42 @@
   
 
   <li class="r1 ">
-    <span class='object_link'><a href="AlchemyFlux/Service.html#start-class_method" title="AlchemyFlux::Service.start (method)">start</a></span>
-    <small>AlchemyFlux::Service</small>
-  </li>
-  
-
-  <li class="r2 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#start-instance_method" title="AlchemyFlux::Service#start (method)">#start</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
 
-  <li class="r1 ">
+  <li class="r2 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#state-instance_method" title="AlchemyFlux::Service#state (method)">#state</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
 
-  <li class="r2 ">
+  <li class="r1 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#stop-class_method" title="AlchemyFlux::Service.stop (method)">stop</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
 
-  <li class="r1 ">
+  <li class="r2 ">
     <span class='object_link'><a href="Rack/Handler/AlchemyFlux.html#stop-class_method" title="Rack::Handler::AlchemyFlux.stop (method)">stop</a></span>
     <small>Rack::Handler::AlchemyFlux</small>
   </li>
   
 
-  <li class="r2 ">
+  <li class="r1 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#stop-instance_method" title="AlchemyFlux::Service#stop (method)">#stop</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
 
-  <li class="r1 ">
+  <li class="r2 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#to_s-instance_method" title="AlchemyFlux::Service#to_s (method)">#to_s</a></span>
     <small>AlchemyFlux::Service</small>
   </li>
   
 
-  <li class="r2 ">
+  <li class="r1 ">
     <span class='object_link'><a href="AlchemyFlux/Service.html#transactions-instance_method" title="AlchemyFlux::Service#transactions (method)">#transactions</a></span>
     <small>AlchemyFlux::Service</small>
   </li>

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -103,7 +103,7 @@
 </div>
 
     <div id="footer">
-  Generated on Mon Feb 29 10:35:54 2016 by
+  Generated on Mon Feb 29 11:41:56 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.8.7.6 (ruby-2.2.4).
 </div>

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -103,9 +103,9 @@
 </div>
 
     <div id="footer">
-  Generated on Thu Jan 21 10:09:51 2016 by
+  Generated on Mon Feb 29 10:35:54 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 (ruby-2.2.3).
+  0.8.7.6 (ruby-2.2.4).
 </div>
 
   </body>

--- a/examples/example_1_send_message.rb
+++ b/examples/example_1_send_message.rb
@@ -16,7 +16,7 @@ serviceA1.start()
 serviceB1.start()
 
 # Service A1 sending message to B
-response = serviceA1.send_message_to_service('B', {'body' => 'Alice'})
+response = serviceA1.send_request_to_service('B', {'body' => 'Alice'})
 
 puts response['body'] # "Hello Alice"
 

--- a/lib/alchemy-flux.rb
+++ b/lib/alchemy-flux.rb
@@ -309,21 +309,6 @@ module AlchemyFlux
 
     public
 
-    # send a message to queue do not wait for response
-    #
-    # *queue_name*:: The routing key to use
-    # *message*:: The message to be sent
-    def send_message_to_queue(queue_name, message)
-      send_message( @channel.default_exchange, queue_name, message, {
-        message_id:          AlchemyFlux::Service.generateUUID(),
-        type:               'ignore',
-        content_encoding:   '8bit',
-        content_type:       'application/json',
-        expiration:          @options[:timeout],
-        mandatory:           true
-      })
-    end
-
     # send a message to a service, this does not wait for a response
     #
     # *service_name*:: The name of the service

--- a/lib/alchemy-flux.rb
+++ b/lib/alchemy-flux.rb
@@ -309,6 +309,21 @@ module AlchemyFlux
 
     public
 
+    # send a message to queue do not wait for response
+    #
+    # *queue_name*:: The routing key to use
+    # *message*:: The message to be sent
+    def send_message_to_queue(queue_name, message)
+      send_message( @channel.default_exchange, queue_name, message, {
+        message_id:          AlchemyFlux::Service.generateUUID(),
+        type:               'ignore',
+        content_encoding:   '8bit',
+        content_type:       'application/json',
+        expiration:          @options[:timeout],
+        mandatory:           true
+      })
+    end
+
     # send a message to a service, this does not wait for a response
     #
     # *service_name*:: The name of the service
@@ -402,7 +417,7 @@ module AlchemyFlux
     # 2. *session_id*: identifier for session
     #
     def format_HTTP_message(message)
-      {
+      message = {
         # Request Parameters
         'body' =>        message['body']        || "",
         'verb' =>        message['verb']        || "GET",
@@ -419,6 +434,8 @@ module AlchemyFlux
         'session'    =>  message['session'],
         'session_id' =>  message['session_id']
       }
+
+      message
     end
 
     # send a HTTP message to an exchange with routing key

--- a/lib/alchemy-flux.rb
+++ b/lib/alchemy-flux.rb
@@ -399,7 +399,6 @@ module AlchemyFlux
     #
     # 1. *session*: undefined structure that can be passed in the message
     # so that a service does not need to re-authenticate with each message
-    # 2. *session_id*: identifier for session
     #
     def format_HTTP_message(message)
       message = {
@@ -416,8 +415,7 @@ module AlchemyFlux
         'port' =>        message['port']        || 8080,
 
         # Custom Authentication
-        'session'    =>  message['session'],
-        'session_id' =>  message['session_id']
+        'session'    =>  message['session']
       }
 
       message

--- a/lib/alchemy-flux.rb
+++ b/lib/alchemy-flux.rb
@@ -379,11 +379,9 @@ module AlchemyFlux
 
     # format the HTTP message
     #
-    # This format is defined by Alchemy framework HTTP message
+    # The entire body is a JSON string with the keys:
     #
-    # The entire body will be a JSON string with the keys:
-    #
-    # Keys for
+    # Request Information:
     #
     # 1. *body*: A string of body information
     # 2. *verb*: The HTTP verb for the query, e.g. GET
@@ -391,11 +389,13 @@ module AlchemyFlux
     # 4. *path*: the path of the request, e.g. "/v1/users/1337"
     # 5. *query*: an object with keys for query, e.g. {'search': 'flux'}
     #
+    # Call information:
+    #
     # 1. *scheme*: the scheme used for the call
     # 2. *host*: the host called to make the call
     # 3. *port*: the port the call was made on
     #
-    # Custom keys for authentication
+    # Authentication information:
     #
     # 1. *session*: undefined structure that can be passed in the message
     # so that a service does not need to re-authenticate with each message
@@ -434,7 +434,8 @@ module AlchemyFlux
         type:               'http',
         content_encoding:   '8bit',
         content_type:       'application/json',
-        expiration:          @options[:timeout]
+        expiration:          @options[:timeout],
+        mandatory:           true
       }
 
       send_message(exchange, routing_key, http_message, http_message_options)

--- a/lib/alchemy-flux/flux_rack_handler.rb
+++ b/lib/alchemy-flux/flux_rack_handler.rb
@@ -55,6 +55,7 @@ module Rack
 
           # add Alchemy Service so the app may call other services
           rack_env['alchemy.service'] = @@service
+          rack_env['alchemy.session'] = message['session']
 
           status, headers, body = app.call(rack_env)
 

--- a/spec/performance_spec.rb
+++ b/spec/performance_spec.rb
@@ -22,7 +22,7 @@ describe "performance of AlchemyFlux" do
     responses = Queue.new
     st = Time.now()
     (1..calls).each do
-      service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}}) do |response|
+      service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}}) do |response|
         responses << response
       end
     end
@@ -51,7 +51,7 @@ describe "performance of AlchemyFlux" do
 
     st = Time.now()
     (1..calls).each do
-      resp = service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
+      resp = service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
       expect(resp['body']).to eq "hola Bob"
     end
 

--- a/spec/rack_handler_spec.rb
+++ b/spec/rack_handler_spec.rb
@@ -19,7 +19,7 @@ describe Rack::Handler::AlchemyFlux do
       Rack::Handler::AlchemyFlux.start app
       service_a.start
       sleep(0.5)
-      response = service_a.send_message_to_service("rack.service", {})
+      response = service_a.send_request_to_service("rack.service", {})
       expect(response['body']).to eq "hi Bob"
       service_a.stop
       Rack::Handler::AlchemyFlux.stop
@@ -38,10 +38,10 @@ describe Rack::Handler::AlchemyFlux do
       service_a.start
       sleep(0.5)
 
-      response = service_a.send_message_to_resource({'path' => '/alice'})
+      response = service_a.send_request_to_resource({'path' => '/alice'})
       expect(response['body']).to eq "hi /alice"
 
-      response = service_a.send_message_to_resource({'path' => '/bob'})
+      response = service_a.send_request_to_resource({'path' => '/bob'})
       expect(response['body']).to eq "hi /bob"
 
       service_a.stop

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -192,27 +192,6 @@ describe AlchemyFlux::Service do
     end
   end
 
-  describe "#send_message_to_queue" do
-    it 'should send a message to services' do
-      received = false
-      service_a = AlchemyFlux::Service.new("fluxa.service") do |message|
-        received = true
-        {}
-      end
-
-      service_b = AlchemyFlux::Service.new("fluxb.service")
-
-      service_a.start
-      service_b.start
-
-      service_b.send_message_to_queue("fluxa.service", {})
-      sleep(0.1)
-      expect(received).to be true
-      service_a.stop
-      service_b.stop
-    end
-
-  end
 
   describe "#send_message_to_service" do
     it 'should send a message to services' do

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -92,7 +92,7 @@ describe AlchemyFlux::Service do
       service_b.start
 
       service_a.stop
-      expect(service_b.send_message_to_service("fluxa.service", {})).to eq AlchemyFlux::TimeoutError
+      expect(service_b.send_request_to_service("fluxa.service", {})).to eq AlchemyFlux::TimeoutError
       service_b.stop
     end
 
@@ -108,7 +108,7 @@ describe AlchemyFlux::Service do
       service_b.start
 
       response_queue = Queue.new
-      service_b.send_message_to_service("fluxa.service", {}) do |response|
+      service_b.send_request_to_service("fluxa.service", {}) do |response|
         response_queue << response
       end
       sleep(0.05)
@@ -132,7 +132,7 @@ describe AlchemyFlux::Service do
       service_b.start
 
       response_queue = Queue.new
-      service_b.send_message_to_service("fluxa.service", {}) do |response|
+      service_b.send_request_to_service("fluxa.service", {}) do |response|
         response_queue << response
       end
       sleep(0.01)
@@ -156,13 +156,13 @@ describe AlchemyFlux::Service do
       service_b.start
 
       response_queue = Queue.new
-      service_b.send_message_to_service("fluxa.service", {}) do |response|
+      service_b.send_request_to_service("fluxa.service", {}) do |response|
         response_queue << response
       end
       sleep(0.1)
       Thread.new do service_a.stop end
       sleep(0.3)
-      expect(service_b.send_message_to_service("fluxa.service", {})).to eq AlchemyFlux::TimeoutError
+      expect(service_b.send_request_to_service("fluxa.service", {})).to eq AlchemyFlux::TimeoutError
 
       response = response_queue.pop
 
@@ -180,10 +180,10 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
+      response = service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
       expect(response['body']).to eq "hi Bob"
 
-      response = service_a.send_message_to_service("fluxb.service", {'body' => {'name' => "Bob"}})
+      response = service_a.send_request_to_service("fluxb.service", {'body' => {'name' => "Bob"}})
       expect(response['body']).to be_empty
 
 
@@ -192,7 +192,7 @@ describe AlchemyFlux::Service do
     end
   end
 
-  describe "#send_message_to_queue" do
+  describe "#send_message_to_service" do
     it 'should send a message to services' do
       received = false
       service_a = AlchemyFlux::Service.new("fluxa.service") do |message|
@@ -205,7 +205,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_queue("fluxa.service", {})
+      service_b.send_message_to_service("fluxa.service", {})
       sleep(0.1)
       expect(received).to be true
       service_a.stop
@@ -214,7 +214,9 @@ describe AlchemyFlux::Service do
 
   end
 
-  describe "#send_message_to_service" do
+
+
+  describe "#send_request_to_service" do
 
     it 'should send and receive messages between services' do
       service_a = AlchemyFlux::Service.new("fluxa.service") do |message|
@@ -226,7 +228,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
+      response = service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
       expect(response['body']).to eq "hi Bob"
       service_a.stop
       service_b.stop
@@ -244,7 +246,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {'body' => '{"name" : "Bob"}'})
+      response = service_b.send_request_to_service("fluxa.service", {'body' => '{"name" : "Bob"}'})
       expect(response['body']).to eq "hi Bob"
       service_a.stop
       service_b.stop
@@ -264,7 +266,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {'body' => '{"name" : "Bob"}'})
+      response = service_b.send_request_to_service("fluxa.service", {'body' => '{"name" : "Bob"}'})
       expect(response['body']).to eq "hi Bob"
       expect(response['headers']["X-header"]).to eq "header1"
       service_a.stop
@@ -285,7 +287,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {'body' => '{"name" : "Bob"}'})
+      response = service_b.send_request_to_service("fluxa.service", {'body' => '{"name" : "Bob"}'})
       expect(response['body']).to eq "hi Bob"
       expect(response['status_code']).to eq 201
       service_a.stop
@@ -294,7 +296,7 @@ describe AlchemyFlux::Service do
 
     it 'should be able to send messages within the service call' do
       service_a = AlchemyFlux::Service.new("fluxa.service") do |message|
-        resp = service_a.send_message_to_service("fluxb.service", {})
+        resp = service_a.send_request_to_service("fluxb.service", {})
         {'body' => "hi #{resp['body']}"}
       end
 
@@ -305,7 +307,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {})
+      response = service_b.send_request_to_service("fluxa.service", {})
       expect(response['body']).to eq "hi Bob"
       service_a.stop
       service_b.stop
@@ -316,7 +318,7 @@ describe AlchemyFlux::Service do
       service_a = AlchemyFlux::Service.new("fluxa.service") do |message|
         if first
           first = !first
-          resp = service_a.send_message_to_service("fluxa.service", {})
+          resp = service_a.send_request_to_service("fluxa.service", {})
           {'body' => "hi #{resp['body']}"}
         else
           {'body' => 'Bob'}
@@ -328,7 +330,7 @@ describe AlchemyFlux::Service do
       service_a.start
       service_b.start
 
-      response = service_b.send_message_to_service("fluxa.service", {})
+      response = service_b.send_request_to_service("fluxa.service", {})
       expect(response['body']).to eq "hi Bob"
       service_a.stop
       service_b.stop
@@ -351,7 +353,7 @@ describe AlchemyFlux::Service do
       expect(service_a.processing_messages).to eq 0
 
       response = Queue.new
-      service_b.send_message_to_service("fluxa.service", {}) do |resp|
+      service_b.send_request_to_service("fluxa.service", {}) do |resp|
         response << resp
       end
       sleep(0.05)
@@ -378,7 +380,7 @@ describe AlchemyFlux::Service do
       service_b.start
 
       block = Queue.new
-      service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}}) do |response|
+      service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}}) do |response|
         block << response
       end
 
@@ -404,7 +406,7 @@ describe AlchemyFlux::Service do
         service_b.start
 
         block = Queue.new
-        service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}}) do |response|
+        service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}}) do |response|
           block << response
         end
         response = block.pop
@@ -425,7 +427,7 @@ describe AlchemyFlux::Service do
         service_a.start
         service_b.start
 
-        response = service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
+        response = service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
 
         expect(response).to eq AlchemyFlux::TimeoutError
         expect(service_b.transactions.length).to eq 0
@@ -444,7 +446,7 @@ describe AlchemyFlux::Service do
         service_a.start
         service_b.start
 
-        response = service_b.send_message_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
+        response = service_b.send_request_to_service("fluxa.service", {'body' => {'name' => "Bob"}})
 
         expect(response['status_code']).to eq 500
         expect(service_b.transactions.length).to eq 0
@@ -458,7 +460,7 @@ describe AlchemyFlux::Service do
 
         service_b.start
 
-        expect(service_b.send_message_to_service("not_a_servoces.service", {})).to eq AlchemyFlux::MessageNotDeliveredError
+        expect(service_b.send_request_to_service("not_a_servoces.service", {})).to eq AlchemyFlux::MessageNotDeliveredError
         expect(service_b.transactions.length).to eq 0
 
         service_b.stop

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -192,6 +192,28 @@ describe AlchemyFlux::Service do
     end
   end
 
+  describe "#send_message_to_queue" do
+    it 'should send a message to services' do
+      received = false
+      service_a = AlchemyFlux::Service.new("fluxa.service") do |message|
+        received = true
+        {}
+      end
+
+      service_b = AlchemyFlux::Service.new("fluxb.service")
+
+      service_a.start
+      service_b.start
+
+      service_b.send_message_to_queue("fluxa.service", {})
+      sleep(0.1)
+      expect(received).to be true
+      service_a.stop
+      service_b.stop
+    end
+
+  end
+
   describe "#send_message_to_service" do
     it 'should send a message to services' do
       received = false


### PR DESCRIPTION
Changing method names:
- removed MessagePack
- `send_message_to_service` now `send_request_to_service`
- `send_message_to_resource` now `send_request_to_resource`
- `send_message_to_queue` refactored to force HTTP packet format and is now `send_message_to_service` pass logging packet inside of `body` to `send_message_to_service`
- `send_message_to_resource` added to allow non-response messages sent to resources
- All message are now HTTP packet format, so logging must be updated.
