### PR TITLE
DS-2925 Fix Critical vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .yardoc/*
 *.gem
 .bundle/
+
+# Ignore temporary files created by editors etc
+.vscode/
+*.log
+.idea/*
+.run/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,15 @@ matrix:
     - rvm: 2.5.1
     - rvm: 2.4.4
     - rvm: 2.3.7
+    - rvm: 2.7.3
 
 cache: bundler
 
 before_install: gem install bundler:$(grep -A 1 'BUNDLED WITH' Gemfile.lock | sed -n 2p | tr -d ' ')
+
+before_script:
+  - bundle exec bundle-audit update
+  - bundle exec bundle-audit check
 
 script: bundle exec rspec --profile --format documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ## v1.3.1
 
-- Critical vulnerabilities update [DS-2925](https://loyaltynz.atlassian.net/browse/DS-2925)
+- Critical vulnerabilities update
+  - Bump `rack` from `2.0.5` to `2.2.7`
+  - Bump `rake` from `12.3.1` to `12.3.3`
+  - Bump `yard` from `0.9.15` to `0.9.34`
 
 ## v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Support Ruby 2.7
 
+## v1.3.1
+
+- Critical vulnerabilities update [DS-2925](https://loyaltynz.atlassian.net/browse/DS-2925)
+
 ## v1.3.0
 
 - Routine maintenance pass, including general `bundle update` and minimum Ruby version bump from 2.4.2 to 2.4.4.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GEM
       thor (~> 1.0)
     diff-lcs (1.3)
     eventmachine (1.2.7)
-    rack (2.0.5)
-    rake (12.3.1)
+    rack (2.2.7)
+    rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -36,7 +36,7 @@ GEM
     rspec-support (3.8.0)
     thor (1.1.0)
     uuidtools (2.1.5)
-    yard (0.9.15)
+    yard (0.9.34)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
     amqp (1.8.0)
       amq-protocol (>= 2.2.0)
       eventmachine
+    bundler-audit (0.9.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 1.0)
     diff-lcs (1.3)
     eventmachine (1.2.7)
     rack (2.0.5)
@@ -31,6 +34,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    thor (1.1.0)
     uuidtools (2.1.5)
     yard (0.9.15)
 
@@ -39,10 +43,11 @@ PLATFORMS
 
 DEPENDENCIES
   alchemy-flux!
+  bundler-audit
   rake (~> 12.3)
   rspec (~> 3.8)
   rspec-mocks (~> 3.8)
   yard (~> 0.9)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/alchemy-flux.gemspec
+++ b/alchemy-flux.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do | s |
   s.add_development_dependency 'rspec-mocks',  '~>  3.8'
   s.add_development_dependency 'rake',         '~> 12.3'
   s.add_development_dependency 'yard',         '~>  0.9'
+  s.add_development_dependency 'bundler-audit'
 end


### PR DESCRIPTION
## Overview

[DS-2925](https://loyaltynz.atlassian.net/browse/DS-2925)


## What is the change?
  - Bump `rack` from `2.0.5` to `2.2.7`
  - Bump `rake` from `12.3.1` to `12.3.3`
  - Bump `yard` from `0.9.15` to `0.9.34`
  - Added `bundle-audit` into CICD steps
  
## How was this change made?

## How do I use/reproduce this change?

## Notes



[DS-2925]: https://loyaltynz.atlassian.net/browse/DS-2925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ